### PR TITLE
Check pull-request base against default branch and not hard-coded master

### DIFF
--- a/mjolnir.go
+++ b/mjolnir.go
@@ -20,6 +20,11 @@ var (
 // closeRelatedIssues Closes issues listed in the PR description.
 func closeRelatedIssues(ctx context.Context, client *github.Client, owner string, repositoryName string, pr *github.PullRequest, dryRun bool) error {
 	issueNumbers := parseIssueFixes(pr.GetBody())
+	repo, _, err := client.Repositories.Get(context.Background(), owner, repositoryName)
+	if err != nil {
+		return fmt.Errorf("unable to access repository %s/%s: %w", owner, repositoryName, err)
+	}
+	
 
 	for _, issueNumber := range issueNumbers {
 		log.Printf("PR #%d: closes issue #%d, add milestones %s", pr.GetNumber(), issueNumber, pr.Milestone.GetTitle())
@@ -31,7 +36,7 @@ func closeRelatedIssues(ctx context.Context, client *github.Client, owner string
 		}
 
 		// Add comment if needed
-		if pr.Base.GetRef() != "master" {
+		if pr.Base.GetRef() != repo.DefaultBranch {
 			message := fmt.Sprintf("Closed by #%d.", pr.GetNumber())
 
 			log.Printf("PR #%d: issue #%d, add comment: %s", pr.GetNumber(), issueNumber, message)

--- a/mjolnir.go
+++ b/mjolnir.go
@@ -20,11 +20,11 @@ var (
 // closeRelatedIssues Closes issues listed in the PR description.
 func closeRelatedIssues(ctx context.Context, client *github.Client, owner string, repositoryName string, pr *github.PullRequest, dryRun bool) error {
 	issueNumbers := parseIssueFixes(pr.GetBody())
-	repo, _, err := client.Repositories.Get(context.Background(), owner, repositoryName)
+
+	repo, _, err := client.Repositories.Get(ctx, owner, repositoryName)
 	if err != nil {
 		return fmt.Errorf("unable to access repository %s/%s: %w", owner, repositoryName, err)
 	}
-	
 
 	for _, issueNumber := range issueNumbers {
 		log.Printf("PR #%d: closes issue #%d, add milestones %s", pr.GetNumber(), issueNumber, pr.Milestone.GetTitle())
@@ -36,7 +36,7 @@ func closeRelatedIssues(ctx context.Context, client *github.Client, owner string
 		}
 
 		// Add comment if needed
-		if pr.Base.GetRef() != repo.DefaultBranch {
+		if pr.Base.GetRef() != repo.GetDefaultBranch() {
 			message := fmt.Sprintf("Closed by #%d.", pr.GetNumber())
 
 			log.Printf("PR #%d: issue #%d, add comment: %s", pr.GetNumber(), issueNumber, message)

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ Close issues related to the merge of a pull request.
 Useful:
 
 - to close multiple issues related to a pull request.
-- to close issues related to a pull request not based on the default branch (i.e. `master`).
+- to close issues related to a pull request not based on the default branch (ex: `master`, `main`).
 For example, when a branch is related to version (e.g. `v1.5`, `v2.0`, ...)
 
 ## Supported Syntax


### PR DESCRIPTION
Hi!

Thanks for the great action! I wondered if you might accept a small tweak to the comparison of the base reference of the pull request. In order to support branches other than `master` as the default branch I have pulled the information from the repository `defaultBranch` variable.

Does this seem like a reasonable change?